### PR TITLE
BUG: Always request the full input image

### DIFF
--- a/include/itkFixedPointInverseDisplacementFieldImageFilter.h
+++ b/include/itkFixedPointInverseDisplacementFieldImageFilter.h
@@ -142,6 +142,9 @@ protected:
 
   void GenerateData( );
   void GenerateOutputInformation();
+
+  virtual void GenerateInputRequestedRegion() ITK_OVERRIDE;
+
   unsigned int m_NumberOfIterations;
 
 

--- a/include/itkFixedPointInverseDisplacementFieldImageFilter.hxx
+++ b/include/itkFixedPointInverseDisplacementFieldImageFilter.hxx
@@ -190,6 +190,30 @@ FixedPointInverseDisplacementFieldImageFilter<TInputImage,TOutputImage>
 }
 
 
+
+//----------------------------------------------------------------------------
+template<class TInputImage, class TOutputImage>
+void
+FixedPointInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>
+::GenerateInputRequestedRegion()
+{
+  // call the superclass's implementation of this method
+  Superclass::GenerateInputRequestedRegion();
+
+  if ( !this->GetInput() )
+    {
+    return;
+    }
+
+  // get pointers to the input and output
+  InputImageType *inputPtr = const_cast< InputImageType * >( this->GetInput() );
+
+  // Request the entire input image
+  InputImageRegionType inputRegion;
+  inputRegion = inputPtr->GetLargestPossibleRegion();
+  inputPtr->SetRequestedRegion(inputRegion);
+}
+
 //----------------------------------------------------------------------------
 template<class TInputImage, class TOutputImage>
 void FixedPointInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::PrintSelf(


### PR DESCRIPTION
The full domain of the input displacement field may be needed.

This addresses segmentation faults encountered when the requested
region does not match in largest possible region.