### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkFixedPointInverseDisplacementFieldImageFilter.h
+++ b/include/itkFixedPointInverseDisplacementFieldImageFilter.h
@@ -55,6 +55,8 @@ class ITK_EXPORT FixedPointInverseDisplacementFieldImageFilter :
     public ImageToImageFilter<TInputImage,TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FixedPointInverseDisplacementFieldImageFilter);
+
   /** Standard class type alias. */
   using Self = FixedPointInverseDisplacementFieldImageFilter;
   using Superclass = ImageToImageFilter<TInputImage,TOutputImage>;
@@ -151,9 +153,6 @@ protected:
 
 
 private:
-  FixedPointInverseDisplacementFieldImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   OutputImageSizeType                      m_Size;              // Size of the output image
   OutputImageSpacingType                   m_OutputSpacing;     // output image spacing
   OutputImageOriginPointType               m_OutputOrigin;      // output image origin


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.