### PR TITLE
STYLE: Move Python test to wrapping/test/CMakeLists.txt

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,3 @@ itk_add_test(NAME FixedPointInverseDisplacementFieldTest
     DATA{Input/DisplacementField.nii.gz}
     ${FixedPointInverseDisplacementFieldTestTestDriverOutput}
   )
-
-itk_python_expression_add_test(NAME FixedPointInverseDisplacementFieldPythonTest
-  EXPRESSION "instance = itk.FixedPointInverseDisplacementFieldImageFilter.New()")

--- a/wrapping/test/CMakeLists.txt
+++ b/wrapping/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+
+itk_python_expression_add_test(NAME FixedPointInverseDisplacementFieldPythonTest
+  EXPRESSION "instance = itk.FixedPointInverseDisplacementFieldImageFilter.New()")
+


### PR DESCRIPTION
Required in ITK 5.

A step towards a working Doxygen Nightly.