### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE

### DIFF
--- a/include/itkFixedPointInverseDisplacementFieldImageFilter.h
+++ b/include/itkFixedPointInverseDisplacementFieldImageFilter.h
@@ -59,7 +59,7 @@ class ITK_TEMPLATE_EXPORT FixedPointInverseDisplacementFieldImageFilter
   : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FixedPointInverseDisplacementFieldImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(FixedPointInverseDisplacementFieldImageFilter);
 
   /** Standard class type alias. */
   using Self = FixedPointInverseDisplacementFieldImageFilter;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.