### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkFixedPointInverseDisplacementFieldImageFilter.hxx
+++ b/include/itkFixedPointInverseDisplacementFieldImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFixedPointInverseDisplacementFieldImageFilter_hxx
 #define itkFixedPointInverseDisplacementFieldImageFilter_hxx
 
-#include "itkFixedPointInverseDisplacementFieldImageFilter.h"
 #include <iostream>
 
 namespace itk


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

