### PR TITLE
BUG: Fix header formatting in README.rst

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -5,10 +5,10 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.4
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.4
     with:
       test-notebooks: false
     secrets:

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ITKFixedPointInverseDisplacementField
-=================================
+=====================================
 .. image:: https://github.com/InsightSoftwareConsortium/ITKFixedPointInverseDisplacementField/workflows/Build,%20test,%20package/badge.svg
 
 ITKFixedPointInverseDisplacementField takes a displacement field as input and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "itk-fixedpointinversedisplacementfield"
-version = "1.1.0"
+version = "1.1.1"
 description = "Takes a displacement field as input and computes the displacement field that is its inverse."
 readme = "README.rst"
 license = {file = "LICENSE"}
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "itk == 5.4.*",
 ]
@@ -48,7 +48,7 @@ Homepage = "https://github.com/InsightSoftwareConsortium/ITKFixedPointInverseDis
 # The versions of CMake to allow. If CMake is not present on the system or does
 # not pass this specifier, it will be downloaded via PyPI if possible. An empty
 # string will disable this check.
-cmake.version = ">=3.16.3"
+cmake.version = ">=3.22.1"
 
 # A list of args to pass to CMake when configuring the project. Setting this in
 # config or envvar will override toml. See also ``cmake.define``.


### PR DESCRIPTION
Underline of a title must extend at least as far as the right edge of the title text (https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections). Currently, `twine check` in the `Build, test, package` workflow fails due to this error.