### PR TITLE
WIP: Test GHCR mirror pre-pull for dockcross images

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -8,7 +8,7 @@ jobs:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.4
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.4
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@ghcr-mirror-dockcross-images
     with:
       test-notebooks: false
     secrets:


### PR DESCRIPTION
Testing the GHCR mirror pre-pull step from InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction#124.

This PR temporarily references the `ghcr-mirror-dockcross-images` branch to verify that the pre-pull + fallback logic works correctly for this module's Python wheel builds.

**This is a test PR and will be closed after validation.**